### PR TITLE
Adding curl for systems (MacOS) without wget

### DIFF
--- a/flann/Makefile
+++ b/flann/Makefile
@@ -5,7 +5,11 @@ FLANN_LIB=$(FLANN_DIR)/lib/libflann_cpp.so
 all: ${FLANN_LIB}
 
 $(FLANN_DIR).tar.gz:
+ifeq (, $(shell which curl))
 	wget -O $@ https://github.com/mariusmuja/flann/archive/${FLANN_PV}-src.tar.gz
+else
+	curl -o $@ -L https://github.com/mariusmuja/flann/archive/${FLANN_PV}-src.tar.gz
+endif
 
 $(FLANN_LIB): ${FLANN_DIR}.tar.gz
 	tar -xzvf $<

--- a/redis/Makefile
+++ b/redis/Makefile
@@ -1,5 +1,5 @@
-REDIS_PV=2.8.19
-HIREDIS_PV=0.13.0
+REDIS_PV=2.8.22
+HIREDIS_PV=0.13.3
 
 REDIS_SERVER=redis-${REDIS_PV}/src/redis-server
 HIREDIS_LIB=hiredis-${HIREDIS_PV}/libhiredis.a
@@ -7,10 +7,18 @@ HIREDIS_LIB=hiredis-${HIREDIS_PV}/libhiredis.a
 all: ${REDIS_SERVER} $(HIREDIS_LIB)
 
 redis-${REDIS_PV}.tar.gz:
+ifeq (, $(shell which curl))
 	wget -O $@ https://github.com/antirez/redis/archive/${REDIS_PV}.tar.gz
+else
+	curl -o $@ -L https://github.com/antirez/redis/archive/${REDIS_PV}.tar.gz
+endif
 
 hiredis-${HIREDIS_PV}.tar.gz:
+ifeq (, $(shell which curl))
 	wget -O $@ https://github.com/redis/hiredis/archive/v${HIREDIS_PV}.tar.gz
+else
+	curl -o $@ -L https://github.com/redis/hiredis/archive/v${HIREDIS_PV}.tar.gz
+endif
 
 $(REDIS_SERVER): redis-${REDIS_PV}.tar.gz
 	tar -xzvf $<


### PR DESCRIPTION
Newly cloned CoEVP repos require that both redis and flann
be installed locally. The Makefiles in their respective
directories download tarballs, unpack them and then build the
packages. Previously, wget was used to download the tarballs
and this command isn't present on OSX. Added logic in Makefiles
to choose curl or wget depending on system in use.
