### PR TITLE
Add build variable COEVP_SILO_WITH_HDF5.

### DIFF
--- a/silo/Makefile
+++ b/silo/Makefile
@@ -1,6 +1,9 @@
 SILO_PV=4.10.2
 SILO_LIB=silo/lib/libsiloh5.a
 
+# Conditionally set defaults for --with-hdf5 if COEVP_SILO_WITH_HDF5 is not already set.
+COEVP_SILO_WITH_HDF5 ?= "/usr/include,/usr/lib"
+
 all: $(SILO_LIB)
 
 silo-${SILO_PV}.tar.gz:
@@ -12,7 +15,7 @@ endif
 
 $(SILO_LIB): silo-${SILO_PV}.tar.gz
 	tar -xzvf $<
-	cd silo-${SILO_PV} && ./configure --prefix=$(CURDIR)/silo --with-hdf5=/usr/include,/usr/lib --enable-shared --disable-fortran
+	cd silo-${SILO_PV} && ./configure --prefix=$(CURDIR)/silo --with-hdf5=$(COEVP_SILO_WITH_HDF5) --enable-shared --disable-fortran
 	make -C silo-${SILO_PV}
 	make -C silo-${SILO_PV} install
 


### PR DESCRIPTION
When set, COEVP_SILO_WITH_HDF5's value will be used as the argument string
passed to SILO's --with-hdf5 option. When not set, a default value of
'/usr/include,/usr/lib' is used instead.